### PR TITLE
word_frequency no longer returns None if it does not detect tokens

### DIFF
--- a/wordfreq/__init__.py
+++ b/wordfreq/__init__.py
@@ -227,7 +227,12 @@ def word_frequency(word, lang, wordlist='combined', default=0.):
     """
     freqs = get_frequency_dict(lang, wordlist)
     combined_value = None
-    for token in tokenize(word, lang):
+    tokens = tokenize(word, lang)
+
+    if len(tokens) == 0:
+        return default
+
+    for token in tokens:
         if token not in freqs:
             # If any word is missing, just return the default value
             return default


### PR DESCRIPTION
`word_frequency` previously returned `None` if it could not detect any tokens. It now returns `default`.