### PR TITLE
Fix tokenization of SE Asian and South Asian scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name="wordfreq",
-    version='1.4',
+    version='1.4.1',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     url='http://github.com/LuminosoInsight/wordfreq/',

--- a/tests/test.py
+++ b/tests/test.py
@@ -189,3 +189,8 @@ def test_ideographic_fallback():
     eq_(tokenize('"การเล่นดนตรี" means "playing music"', 'en'),
         ['การเล่นดนตรี', 'means', 'playing', 'music'])
 
+    # Test Khmer, a script similar to Thai
+    eq_(tokenize('សូមស្វាគមន៍', 'km'), ['សូមស្វាគមន៍'])
+
+    # Test Hindi -- tokens split where there are spaces, and not where there aren't
+    eq_(tokenize('हिन्दी विक्षनरी', 'hi'), ['हिन्दी', 'विक्षनरी'])

--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -17,7 +17,7 @@ SPACELESS_SCRIPTS = [
 
 
 def _make_spaceless_expr():
-    pieces = [r'\p{IsIdeo}'] + [r'\p{%s}' % script_code for script_code in SPACELESS_SCRIPTS]
+    pieces = [r'\p{IsIdeo}'] + [r'\p{Script=%s}' % script_code for script_code in SPACELESS_SCRIPTS]
     return ''.join(pieces)
 
 

--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -6,21 +6,29 @@ TOKEN_RE = regex.compile(r"""
     # Case 1: a special case for non-spaced languages
     # -----------------------------------------------
 
-    # When we see characters that are Han ideographs (\p{IsIdeo}), hiragana
-    # (\p{Script=Hiragana}), or Thai (\p{Script=Thai}), we allow a sequence
-    # of those characters to be glued together as a single token.
+    # Some scripts are written without spaces, and the Unicode algorithm
+    # seems to overreact and insert word breaks between all their letters.
+    # When we see sequences of characters in these scripts, we make sure not
+    # to break them up. Such scripts include Han ideographs (\p{IsIdeo}),
+    # hiragana (\p{Script=Hiragana}), and many Southeast Asian scripts:
+    # Thai, Khmer, Lao, and Myanmar.
     #
     # Without this case, the standard rule (case 2) would make each character
     # a separate token. This would be the correct behavior for word-wrapping,
     # but a messy failure mode for NLP tokenization.
     #
-    # It is, of course, better to use a tokenizer that is designed for Chinese,
-    # Japanese, or Thai text. This is effectively a fallback for when the wrong
-    # tokenizer is used.
+    # Some South Asian scripts also manage to create unexpected word breaks
+    # even though they have spaces: Devanagari, Gurmukhi, Sundanese, Tamil,
+    # Telugu, and Tibetan.
+    #
+    # It is, of course, better to use a tokenizer that is designed for Chinese
+    # or Japanese text if that's what you have. When alternate tokenizers are
+    # available, this is effectively a fallback for when the wrong tokenizer
+    # is used.
     #
     # This rule is listed first so that it takes precedence.
 
-    [\p{IsIdeo}\p{Script=Hiragana}\p{Script=Thai}]+ |
+    [\p{IsIdeo}\p{Script=Hiragana}\p{Script=Thai}\p{Script=Khmr}\p{Script=Laoo}\p{Script=Mymr}\p{Script=Guru}\p{Script=Deva}\p{Script=Sund}\p{Script=Taml}\p{Script=Telu}\p{script=Tibt}]+ |
 
     # Case 2: standard Unicode segmentation
     # -------------------------------------

--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -42,7 +42,7 @@ TOKEN_RE = regex.compile(r"""
     # If you have Chinese or Japanese text, it's certainly better to use a
     # tokenizer that's designed for it. Elsewhere in this file, we have
     # specific tokenizers that can handle Chinese and Japanese. With this
-    # rule, though, at lest this general tokenizer will fail less badly
+    # rule, though, at least this general tokenizer will fail less badly
     # on those languages.
     #
     # This rule is listed first so that it takes precedence. The placeholder

--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -39,10 +39,10 @@ TOKEN_RE = regex.compile(r"""
     # a separate token. This would be the correct behavior for word-wrapping,
     # but a messy failure mode for NLP tokenization.
     #
-    # It is, of course, better to use a tokenizer that is designed for Chinese
-    # or Japanese text if that's what you have. When alternate tokenizers are
-    # available, this is effectively a fallback for when the wrong tokenizer
-    # is used.
+    # If you have Chinese or Japanese text, it's certainly better to use a
+    # tokenizer that's designed for it. In those cases, the purpose of this
+    # rule is to make this general tokenizer fail less badly on languages
+    # that need specific tokenization.
     #
     # This rule is listed first so that it takes precedence. The placeholder
     # <SPACELESS> will be replaced by the complex range expression made by

--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -40,9 +40,10 @@ TOKEN_RE = regex.compile(r"""
     # but a messy failure mode for NLP tokenization.
     #
     # If you have Chinese or Japanese text, it's certainly better to use a
-    # tokenizer that's designed for it. In those cases, the purpose of this
-    # rule is to make this general tokenizer fail less badly on languages
-    # that need specific tokenization.
+    # tokenizer that's designed for it. Elsewhere in this file, we have
+    # specific tokenizers that can handle Chinese and Japanese. With this
+    # rule, though, at lest this general tokenizer will fail less badly
+    # on those languages.
     #
     # This rule is listed first so that it takes precedence. The placeholder
     # <SPACELESS> will be replaced by the complex range expression made by

--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -18,8 +18,8 @@ TOKEN_RE = regex.compile(r"""
     # but a messy failure mode for NLP tokenization.
     #
     # Some South Asian scripts also manage to create unexpected word breaks
-    # even though they have spaces: Devanagari, Gurmukhi, Sundanese, Tamil,
-    # Telugu, and Tibetan.
+    # even though they have spaces: Devanagari, Gurmukhi, Sindhi, Sundanese,
+    # Tamil, Telugu, and Tibetan.
     #
     # It is, of course, better to use a tokenizer that is designed for Chinese
     # or Japanese text if that's what you have. When alternate tokenizers are
@@ -28,7 +28,7 @@ TOKEN_RE = regex.compile(r"""
     #
     # This rule is listed first so that it takes precedence.
 
-    [\p{IsIdeo}\p{Script=Hiragana}\p{Script=Thai}\p{Script=Khmr}\p{Script=Laoo}\p{Script=Mymr}\p{Script=Guru}\p{Script=Deva}\p{Script=Sund}\p{Script=Taml}\p{Script=Telu}\p{script=Tibt}]+ |
+    [\p{IsIdeo}\p{Script=Hiragana}\p{Script=Thai}\p{Script=Khmr}\p{Script=Laoo}\p{Script=Mymr}\p{Script=Deva}\p{Script=Guru}\p{Script=Sind}\p{Script=Sund}\p{Script=Taml}\p{Script=Telu}\p{script=Tibt}]+ |
 
     # Case 2: standard Unicode segmentation
     # -------------------------------------


### PR DESCRIPTION
There are more scripts where we need to add exceptions to the Unicode word-boundary matcher (as I found in ConceptNet):

* More spaceless scripts: Khmer, Lao, Myanmar
* Scripts where the algorithm just doesn't seem to account for all the combinations of letters and marks that can come up: Devanagari, Gurmukhi, Sundanese, Tamil, Telugu, Tibetan