### PR TITLE
Tokenize words such as "l'heure" the same way as "l'arc"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name="wordfreq",
-    version='1.5.1',
+    version='1.6',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     url='http://github.com/LuminosoInsight/wordfreq/',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name="wordfreq",
-    version='1.6',
+    version='1.5.2',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     url='http://github.com/LuminosoInsight/wordfreq/',

--- a/tests/test_french.py
+++ b/tests/test_french.py
@@ -1,0 +1,19 @@
+from nose.tools import eq_, assert_almost_equal
+from wordfreq import tokenize, word_frequency
+
+
+def test_apostrophes():
+    for lang in ('fr', 'ca', 'oc'):
+        eq_(tokenize("langues d'oïl", lang),
+            ['langues', "d", 'oïl'])
+        eq_(tokenize("langues d'oïl", lang, include_punctuation=True),
+            ['langues', "d'", 'oïl'])
+        eq_(tokenize("l'heure", lang),
+            ['l', 'heure'])
+        eq_(tokenize("l'heure", lang, include_punctuation=True),
+            ["l'", 'heure'])
+        eq_(tokenize("L'Hôpital", lang, include_punctuation=True),
+            ["l'", 'hôpital'])
+        eq_(tokenize("This isn't French", lang),
+            ['this', "isn't", 'french'])
+

--- a/tests/test_french_and_related.py
+++ b/tests/test_french_and_related.py
@@ -17,3 +17,10 @@ def test_apostrophes():
         eq_(tokenize("This isn't French", lang),
             ['this', "isn't", 'french'])
 
+
+def test_catalan():
+    # Catalan orthography is fiddly. Test that we get a short sentence right.
+    eq_(tokenize("M'acabo d'instal·lar.", 'ca'),
+        ['m', 'acabo', 'd', 'instal·lar'])
+    eq_(tokenize("M'acabo d'instal·lar.", 'ca', include_punctuation=True),
+        ["m'", 'acabo', "d'", 'instal·lar', '.'])

--- a/tests/test_french_and_related.py
+++ b/tests/test_french_and_related.py
@@ -3,23 +3,27 @@ from wordfreq import tokenize, word_frequency
 
 
 def test_apostrophes():
-    for lang in ('fr', 'ca', 'oc'):
-        eq_(tokenize("langues d'oïl", lang),
-            ['langues', "d", 'oïl'])
-        eq_(tokenize("langues d'oïl", lang, include_punctuation=True),
-            ['langues', "d'", 'oïl'])
-        eq_(tokenize("l'heure", lang),
-            ['l', 'heure'])
-        eq_(tokenize("l'heure", lang, include_punctuation=True),
-            ["l'", 'heure'])
-        eq_(tokenize("L'Hôpital", lang, include_punctuation=True),
-            ["l'", 'hôpital'])
-        eq_(tokenize("This isn't French", lang),
-            ['this', "isn't", 'french'])
+    # Test that we handle apostrophes in French reasonably.
+    eq_(tokenize("qu'un", 'fr'), ['qu', 'un'])
+    eq_(tokenize("qu'un", 'fr', include_punctuation=True),
+        ["qu'", "un"])
+    eq_(tokenize("langues d'oïl", 'fr'),
+        ['langues', "d", 'oïl'])
+    eq_(tokenize("langues d'oïl", 'fr', include_punctuation=True),
+        ['langues', "d'", 'oïl'])
+    eq_(tokenize("l'heure", 'fr'),
+        ['l', 'heure'])
+    eq_(tokenize("l'heure", 'fr', include_punctuation=True),
+        ["l'", 'heure'])
+    eq_(tokenize("L'Hôpital", 'fr', include_punctuation=True),
+        ["l'", 'hôpital'])
+    eq_(tokenize("This isn't French", 'en'),
+        ['this', "isn't", 'french'])
 
 
-def test_catalan():
-    # Catalan orthography is fiddly. Test that we get a short sentence right.
+def test_catastrophes():
+    # More apostrophes, but this time they're in Catalan, and there's other
+    # mid-word punctuation going on too.
     eq_(tokenize("M'acabo d'instal·lar.", 'ca'),
         ['m', 'acabo', 'd', 'instal·lar'])
     eq_(tokenize("M'acabo d'instal·lar.", 'ca', include_punctuation=True),

--- a/tests/test_french_and_related.py
+++ b/tests/test_french_and_related.py
@@ -17,6 +17,7 @@ def test_apostrophes():
         ["l'", 'heure'])
     eq_(tokenize("L'Hôpital", 'fr', include_punctuation=True),
         ["l'", 'hôpital'])
+    eq_(tokenize("aujourd'hui", 'fr'), ["aujourd'hui"])
     eq_(tokenize("This isn't French", 'en'),
         ['this', "isn't", 'french'])
 


### PR DESCRIPTION
Unicode mentioned a fiddly little rule about splitting between apostrophes and vowels, which Python's regex module faithfully implemented. But in languages where this matters, such as French, it seems they forgot about splitting between apostrophes and the silent "h".

This branch adds another tokenization path that fixes up words such as "l'heure".

It also keeps the apostrophe around when `include_punctuation=True`, like it sounds like it should.