### PR TITLE
Tokenize by graphemes, not codepoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ current_dir = os.path.dirname(__file__)
 README_contents = open(os.path.join(current_dir, 'README.md'),
                        encoding='utf-8').read()
 doclines = README_contents.split("\n")
-dependencies = ['ftfy >= 5', 'msgpack-python', 'langcodes >= 1.4', 'regex >= 2017.06.23']
+dependencies = ['ftfy >= 5', 'msgpack-python', 'langcodes >= 1.4', 'regex == 2017.06.23']
 if sys.version_info < (3, 4):
     dependencies.append('pathlib')
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ current_dir = os.path.dirname(__file__)
 README_contents = open(os.path.join(current_dir, 'README.md'),
                        encoding='utf-8').read()
 doclines = README_contents.split("\n")
-dependencies = ['ftfy >= 5', 'msgpack-python', 'langcodes >= 1.4', 'regex == 2017.06.23']
+dependencies = [
+    'ftfy >= 5', 'msgpack-python', 'langcodes >= 1.4', 'regex == 2017.07.28'
+]
 if sys.version_info < (3, 4):
     dependencies.append('pathlib')
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ current_dir = os.path.dirname(__file__)
 README_contents = open(os.path.join(current_dir, 'README.md'),
                        encoding='utf-8').read()
 doclines = README_contents.split("\n")
-dependencies = ['ftfy >= 4', 'msgpack-python', 'langcodes >= 1.4', 'regex >= 2015']
+dependencies = ['ftfy >= 5', 'msgpack-python', 'langcodes >= 1.4', 'regex >= 2017.06.23']
 if sys.version_info < (3, 4):
     dependencies.append('pathlib')
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -137,6 +137,21 @@ def test_tokenization():
     eq_(tokenize('this text has... punctuation :)', 'en', include_punctuation=True),
         ['this', 'text', 'has', '...', 'punctuation', ':)'])
 
+    # Multi-codepoint emoji sequences such as 'medium-skinned woman with headscarf'
+    # and 'David Bowie' stay together, because our Unicode segmentation algorithm
+    # is up to date
+    eq_(tokenize('emoji test 🧕🏽', 'en'), ['emoji', 'test', '🧕🏽'])
+
+    eq_(tokenize("👨‍🎤 Planet Earth is blue, and there's nothing I can do 🌎🚀", 'en'),
+        ['👨‍🎤', 'planet', 'earth', 'is', 'blue', 'and', "there's",
+         'nothing', 'i', 'can', 'do', '🌎', '🚀'])
+
+    # Water wave, surfer, flag of California (indicates ridiculously complete support
+    # for Unicode 10 and Emoji 5.0)
+    eq_(tokenize("Surf's up 🌊🏄🏴󠁵󠁳󠁣󠁡󠁿'",'en'),
+        ["surf's", "up", "🌊", "🏄", "🏴󠁵󠁳󠁣󠁡󠁿"])
+
+
 
 def test_casefolding():
     eq_(tokenize('WEISS', 'de'), ['weiss'])

--- a/tests/test.py
+++ b/tests/test.py
@@ -152,7 +152,6 @@ def test_tokenization():
         ["surf's", "up", "🌊", "🏄", "🏴󠁵󠁳󠁣󠁡󠁿"])
 
 
-
 def test_casefolding():
     eq_(tokenize('WEISS', 'de'), ['weiss'])
     eq_(tokenize('weiß', 'de'), ['weiss'])

--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -370,11 +370,8 @@ def tokenize(text, lang, include_punctuation=False, external_wordlist=False,
     -----------------------------------
 
     Any kind of language not previously mentioned will just go through the same
-    tokenizer that alphabetic languages use.
-
-    We've tweaked this tokenizer for the case of Indic languages in Brahmic
-    scripts, such as Hindi, Tamil, and Telugu, so that we can handle these
-    languages where the default Unicode algorithm wouldn't quite work.
+    tokenizer that alphabetic languages use. This includes the Brahmic scripts
+    used in Hindi, Tamil, and Telugu, for example.
 
     Southeast Asian languages, such as Thai, Khmer, Lao, and Myanmar, are
     written in Brahmic-derived scripts, but usually *without spaces*. wordfreq


### PR DESCRIPTION
After examining weird edge cases involving multi-codepoint emoji, I realized why we had to have the workaround in our `TOKEN_RE` about not splitting off diacritical marks from words. And the reason for both is the same: we had regular expressions that could stop matching in the middle of a grapheme.

A sufficiently powerful regex engine can match a grapheme using the `\X` symbol. If we make sure that the only way we advance through a string is by matching graphemes, we can avoid these edge cases.

The result is an expression that's simpler at its core, and also tokenizes flags and David Bowie correctly. 👨‍🎤