### PR TITLE
Updated setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ README_contents = open(os.path.join(current_dir, 'README.md'),
                        encoding='utf-8').read()
 doclines = README_contents.split("\n")
 dependencies = [
-    'ftfy >= 5', 'msgpack-python', 'langcodes >= 1.4', 'regex == 2017.07.28'
+    'ftfy >= 5', 'msgpack', 'langcodes >= 1.4', 'regex >= 2017.07.28'
 ]
 if sys.version_info < (3, 4):
     dependencies.append('pathlib')
@@ -36,7 +36,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name="wordfreq",
-    version='1.6.1',
+    version='1.7.0',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     url='http://github.com/LuminosoInsight/wordfreq/',


### PR DESCRIPTION
In the course of trying to package wordfreq for Nix I discovered your setup.py appears out of date; here are my proposed changes:

- in dependencies, update: msgpack-python  to msgpack 
- bumped version to 1.7.0,
- made regex dependency more forgiving in version number, making the condition >= rather than ==.

For the last one, I am not sure, since I don't know if you had particular reasons for demanding a particular revision of regex.