### PR TITLE
Handle Japanese edge cases in `simple_tokenize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## Version 2.0.1 (2018-05-01)
+
+Fixed edge cases that inserted spurious token boundaries when Japanese text is
+run through `simple_tokenize`, because of a few characters that don't match any
+of our "spaceless scripts".
+
+It is not a typical situation for Japanese text to be passed through
+`simple_tokenize`, because Japanese text should instead use the
+Japanese-specific tokenization in `wordfreq.mecab`.
+
+However, some downstream uses of wordfreq have justifiable reasons to pass all
+terms through `simple_tokenize`, even terms that may be in Japanese, and in
+those cases we want to detect only the most obvious token boundaries.
+
+In this situation, we no longer try to detect script changes, such as between
+kanji and katakana, as token boundaries. This particularly allows us to keep
+together Japanese words where ヶ appears betwen kanji, as well as words that
+use the iteration mark 々.
+
+This change does not affect any word frequencies. (The Japanese word list uses
+`wordfreq.mecab` for tokenization, not `simple_tokenize`.)
+
+
+
 ## Version 2.0 (2018-03-14)
 
 The big change in this version is that text preprocessing, tokenization, and

--- a/README.md
+++ b/README.md
@@ -416,9 +416,9 @@ sources:
 
 - Wikipedia, the free encyclopedia (http://www.wikipedia.org)
 
-It contains data from OPUS OpenSubtitles 2016
-(http://opus.lingfil.uu.se/OpenSubtitles2016.php), whose data originates from
-the OpenSubtitles project (http://www.opensubtitles.org/).
+It contains data from OPUS OpenSubtitles 2018
+(http://opus.nlpl.eu/OpenSubtitles.php), whose data originates from the
+OpenSubtitles project (http://www.opensubtitles.org/).
 
 It contains data from various SUBTLEX word lists: SUBTLEX-US, SUBTLEX-UK,
 SUBTLEX-CH, SUBTLEX-DE, and SUBTLEX-NL, created by Marc Brysbaert et al.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name="wordfreq",
-    version='2.0',
+    version='2.0.1',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='info@luminoso.com',
     url='http://github.com/LuminosoInsight/wordfreq/',

--- a/tests/test.py
+++ b/tests/test.py
@@ -204,15 +204,10 @@ def test_arabic():
 
 def test_ideographic_fallback():
     # Try tokenizing Chinese text as English -- it should remain stuck together.
+    #
+    # More complex examples like this, involving the multiple scripts of Japanese,
+    # are in test_japanese.py.
     eq_(tokenize('中国文字', 'en'), ['中国文字'])
-
-    # When Japanese is tagged with the wrong language, it will be split
-    # at script boundaries.
-    ja_text = 'ひらがなカタカナromaji'
-    eq_(
-        tokenize(ja_text, 'en'),
-        ['ひらがな', 'カタカナ', 'romaji']
-    )
 
 
 def test_other_languages():

--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -3,7 +3,7 @@ import unicodedata
 import logging
 import langcodes
 
-from .language_info import get_language_info, SPACELESS_SCRIPTS
+from .language_info import get_language_info, SPACELESS_SCRIPTS, EXTRA_JAPANESE_CHARACTERS
 from .preprocess import preprocess_text, smash_numbers
 
 # Placeholders for CJK functions that we'll import on demand
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 def _make_spaceless_expr():
     scripts = sorted(SPACELESS_SCRIPTS)
     pieces = [r'\p{IsIdeo}'] + [r'\p{Script=%s}' % script_code for script_code in scripts]
-    return ''.join(pieces)
+    return ''.join(pieces) + EXTRA_JAPANESE_CHARACTERS
 
 
 SPACELESS_EXPR = _make_spaceless_expr()


### PR DESCRIPTION
We insert some spurious token boundaries when Japanese text is being run through `simple_tokenize`, because of a few characters that don't match any of our "spaceless scripts".

Japanese text is only run through `simple_tokenize` in unusual situations, where we kind of don't want to tokenize Japanese unless the token boundaries are really obvious, which is the case in ConceptNet. This change should not, for example, affect a language pipeline that is tokenizing Japanese text *as Japanese*, because that would use MeCab, not `simple_tokenize`.