### PR TITLE
Fixes to scripts that accidentally run during tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules --doctest-glob=README.md
+addopts = --doctest-modules --doctest-glob=README.md --ignore=scripts

--- a/scripts/top_n.py
+++ b/scripts/top_n.py
@@ -8,7 +8,7 @@ import wordfreq
 
 N = 1000
 
-
-for lang in sorted(wordfreq.available_languages()):
-    for word in wordfreq.top_n_list(lang, 1000):
-        print('{}\t{}'.format(lang, word))
+if __name__ == '__main__':
+    for lang in sorted(wordfreq.available_languages()):
+        for word in wordfreq.top_n_list(lang, 1000):
+            print('{}\t{}'.format(lang, word))


### PR DESCRIPTION
When you run pytest on wordfreq, it accidentally runs the `top_n.py` script and outputs a bunch of stuff. I've fixed this in two ways:

- Ignoring the `scripts` directory using a pytest option
- Guarding the script `top_n.py` with `if __name__ == '__main__':`