### PR TITLE
Add a mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+# Robyn has used different names and e-mail addresses in the course of this project. Map them all to her current name and e-mail.
+Robyn Speer <rspeer@luminoso.com> <rob@luminoso.com>
+Robyn Speer <rspeer@luminoso.com> <rob@lumino.so>
+Robyn Speer <rspeer@luminoso.com> <rspeer@mit.edu>
+Robyn Speer <rspeer@luminoso.com> <rspeer+gh@luminoso.com>
+


### PR DESCRIPTION
Git 2.23 is out and it respects the `.mailmap` file by default, mapping different names and e-mail addresses to one identity with a canonical name and e-mail address. This allows me to cosmetically clean up some things about my git history, such as unifying four different e-mail addresses.