### PR TITLE
use langcodes 2.0 and deprecate 'match_cutoff'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Version 2.3 (2020-04-16)
+
+- Python 3.5 is the oldest maintained version of Python, and we have stopped
+  claiming support for earlier versions.
+
+- Updated to langcodes 2.0.
+
+- Deprecated the `match_cutoff` parameter, which was intended for situations
+  where we need to approximately match a language code, but was not usefully
+  configurable in those situations.
+
 ## Version 2.2.2 (2020-02-28)
 
 Library change:

--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,14 @@ README_contents = open(os.path.join(current_dir, 'README.md'),
                        encoding='utf-8').read()
 doclines = README_contents.split("\n")
 dependencies = [
-    'msgpack', 'langcodes >= 1.4.1', 'regex >= 2017.07.11, <= 2018.02.21'
+    'msgpack', 'langcodes >= 2', 'regex'
 ]
 if sys.version_info < (3, 4):
     dependencies.append('pathlib')
 
 setup(
     name="wordfreq",
-    version='2.2.2',
+    version='2.3',
     maintainer='Robyn Speer',
     maintainer_email='rspeer@luminoso.com',
     url='http://github.com/LuminosoInsight/wordfreq/',
@@ -46,7 +46,7 @@ setup(
     long_description=README_contents,
     long_description_content_type='text/markdown',
     packages=['wordfreq'],
-    python_requires='>=3.3',
+    python_requires='>=3.5',
     include_package_data=True,
     install_requires=dependencies,
 


### PR DESCRIPTION
Looking at the way we do language matching within wordfreq, there is no coherent reason that `match_cutoff` should be a changeable parameter, so let's start on getting rid of it.