### PR TITLE
Fix regex's inconsistent word breaking around apostrophes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
+## Version 2.3.2 (2020-04-28)
+
+- Relaxing the dependency on regex had an unintended consequence in 2.3.1:
+  it could no longer get the frequency of French phrases such as "l'écran"
+  because their tokenization behavior changed.
+
+  2.3.2 fixes this with a more complex tokenization rule that should handle
+  apostrophes the same across these various versions of regex.
+
 ## Version 2.3.1 (2020-04-22)
 
 - State the dependency on msgpack >= 1.0 in setup.py.
-
+- Relax the dependency on regex to allow versions after 2018.02.08.
 
 ## Version 2.3 (2020-04-16)
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name="wordfreq",
-    version='2.3.1',
+    version='2.3.2',
     maintainer='Robyn Speer',
     maintainer_email='rspeer@luminoso.com',
     url='http://github.com/LuminosoInsight/wordfreq/',

--- a/tests/test_french_and_related.py
+++ b/tests/test_french_and_related.py
@@ -8,6 +8,7 @@ def test_apostrophes():
     assert tokenize("langues d'oïl", 'fr') == ['langues', "d", 'oïl']
     assert tokenize("langues d'oïl", 'fr', include_punctuation=True) == ['langues', "d'", 'oïl']
     assert tokenize("l'heure", 'fr') == ['l', 'heure']
+    assert tokenize("l'ànima", 'ca') == ['l', 'ànima']
     assert tokenize("l'heure", 'fr', include_punctuation=True) == ["l'", 'heure']
     assert tokenize("L'Hôpital", 'fr', include_punctuation=True) == ["l'", 'hôpital']
     assert tokenize("aujourd'hui", 'fr') == ["aujourd'hui"]


### PR DESCRIPTION
Relaxing the dependency on regex had an unintended consequence in 2.3.1: it could no longer get the frequency of French phrases such as "l'écran" because their tokenization behavior changed.

Fix this with a more complex tokenization rule that should handle apostrophes the same across these various versions of regex.

(I ran `black` so it could format these ugly expressions appropriately; there are some miscellaneous formatting changes to tokens.py that came along as a result.)