### PR TITLE
add Œ and œ to initial vowels

### DIFF
--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -31,7 +31,7 @@ SPACELESS_EXPR = _make_spaceless_expr()
 
 # All vowels that might appear at the start of a word in French or Catalan,
 # plus 'h' which would be silent and imply a following vowel sound.
-INITIAL_VOWEL_EXPR = '[AEHIOUÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛaehiouáéíóúàèìòùâêîôû]'
+INITIAL_VOWEL_EXPR = '[AEHIOUÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛŒaehiouáéíóúàèìòùâêîôûœ]'
 
 TOKEN_RE = regex.compile(
     r"""


### PR DESCRIPTION
Œ and œ should be considered as vowels that might appear at the start of a word in French.

For example, "L'œsophage" should be tokenized as ['l', 'œsophage']