### PR TITLE
Add åïö to our list of vowels

### DIFF
--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -31,7 +31,7 @@ SPACELESS_EXPR = _make_spaceless_expr()
 
 # All vowels that might appear at the start of a word in French or Catalan,
 # plus 'h' which would be silent and imply a following vowel sound.
-INITIAL_VOWEL_EXPR = '[AEHIOUÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÅÏÖŒaehiouáéíóúàèìòùâêîôûåïöœ]'
+INITIAL_VOWEL_EXPR = '[AEHIOUYÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÅÏÖŒaehiouyáéíóúàèìòùâêîôûåïöœ]'
 
 TOKEN_RE = regex.compile(
     r"""

--- a/wordfreq/tokens.py
+++ b/wordfreq/tokens.py
@@ -31,7 +31,7 @@ SPACELESS_EXPR = _make_spaceless_expr()
 
 # All vowels that might appear at the start of a word in French or Catalan,
 # plus 'h' which would be silent and imply a following vowel sound.
-INITIAL_VOWEL_EXPR = '[AEHIOUÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛŒaehiouáéíóúàèìòùâêîôûœ]'
+INITIAL_VOWEL_EXPR = '[AEHIOUÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÅÏÖŒaehiouáéíóúàèìòùâêîôûåïöœ]'
 
 TOKEN_RE = regex.compile(
     r"""


### PR DESCRIPTION
I added handling for `y`, `å`, `ï`, and `ö` based on words such as `d'yvonne`, `d'åland`, `l'ïle`, and `d'özil` which we saw in data. 

I matched the sort of the vowels that was there to begin with.

I don't think these changes require adding to the relevant test, but I can be convinced otherwise.