### PR TITLE
work with langcodes 3.0, without language_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 2.4.1 (2021-02-09)
+
+- Changed a log message to not try to call a language by name, to remove
+  the dependency on a database of language names.
+
 ## Version 2.4 (2020-10-01)
 
 - The Exquisite Corpus data has been updated to include Google Books Ngrams

--- a/setup.py
+++ b/setup.py
@@ -30,12 +30,10 @@ doclines = README_contents.split("\n")
 dependencies = [
     'msgpack >= 1.0', 'langcodes >= 2.1', 'regex >= 2020.04.04'
 ]
-if sys.version_info < (3, 4):
-    dependencies.append('pathlib')
 
 setup(
     name="wordfreq",
-    version='2.4.0',
+    version='2.4.1',
     maintainer='Robyn Speer',
     maintainer_email='rspeer@luminoso.com',
     url='http://github.com/LuminosoInsight/wordfreq/',

--- a/wordfreq/__init__.py
+++ b/wordfreq/__init__.py
@@ -141,8 +141,8 @@ def get_frequency_list(lang, wordlist='best', match_cutoff=None):
     if best != lang:
         logger.warning(
             "You asked for word frequencies in language %r. Using the "
-            "nearest match, which is %r (%s)."
-            % (lang, best, langcodes.get(best).language_name('en'))
+            "nearest match, which is %r."
+            % (lang, best)
         )
 
     return read_cBpack(available[best])


### PR DESCRIPTION
langcodes 3.0 does not include a database of language names by default, and instead requires an optional package `language_data` to look up language names.

The only place this was used in wordfreq was in a log message, which I've fixed by removing the language name.